### PR TITLE
An idea for a different version of concerts index page

### DIFF
--- a/app/assets/stylesheets/pages/_concerts_index.scss
+++ b/app/assets/stylesheets/pages/_concerts_index.scss
@@ -7,7 +7,6 @@
 
 .masonry-grid {
   margin-top: 70px;
-  margin-bottom: 100px;
   width: 100%;
   height: 100vh;
   display: grid;

--- a/app/assets/stylesheets/pages/_concerts_index.scss
+++ b/app/assets/stylesheets/pages/_concerts_index.scss
@@ -3,10 +3,16 @@
 .concerts-layout {
   padding: 50px;
   background-color: rgb(20, 20, 20);
+
+  .banner-one {
+    .text-center {
+      margin: 0;
+    }
+  }
 }
 
 .masonry-grid {
-  margin-top: 70px;
+  margin-top: 0px;
   width: 100%;
   height: 100vh;
   display: grid;
@@ -146,11 +152,16 @@
   }
 }
 .hover-disapear:hover {
+
+
   a {
-    color: black;
+    color: #17615de0;
+
   }
   span {
-    color: black;
+    color: #17615de0;
+
+
   }
 
 }

--- a/app/assets/stylesheets/pages/_concerts_index.scss
+++ b/app/assets/stylesheets/pages/_concerts_index.scss
@@ -78,6 +78,7 @@
   border-radius: 5px;
   opacity: 0.8;
 }
+
 .masonry-date {
   position: absolute;
   top: 50%;
@@ -108,6 +109,12 @@
   font-size: 50px;
   font-family: 'Bebas Neue', cursive;
   transition: opacity ease-in-out 0.3s;
+  // text-shadow: 0px 0px 50px rgb(255, 255, 255);
+  background-color: white;
+  // line-height: 3.5rem;
+  height: fit-content;
+  width: fit-content;
+  padding: 0px 7px;
 }
 
 .one {
@@ -131,5 +138,11 @@
   }
   img {
     opacity: 0.5;
+  }
+}
+
+.concerts-layout {
+  .btn-accent {
+    width: 150px;
   }
 }

--- a/app/assets/stylesheets/pages/_concerts_index.scss
+++ b/app/assets/stylesheets/pages/_concerts_index.scss
@@ -67,6 +67,7 @@
   border-radius: 5px;
   position: relative;
   box-shadow: 0px 0px 30px rgb(15, 15, 15);
+
 }
 
 
@@ -110,11 +111,28 @@
   font-family: 'Bebas Neue', cursive;
   transition: opacity ease-in-out 0.3s;
   // text-shadow: 0px 0px 50px rgb(255, 255, 255);
-  background-color: white;
-  // line-height: 3.5rem;
-  height: fit-content;
+  line-height: 2.5rem;
   width: fit-content;
-  padding: 0px 7px;
+  min-height: 200px;
+  min-width: 180px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  padding: 20px 30px;
+  background: rgb(255,255,255);
+  background: radial-gradient(circle, rgba(255,255,255,1) 0%, rgba(255,255,255,0) 70%);  height: fit-content;
+
+
+  span {
+    font-size: 22px;
+    font-family: $body-font;
+    margin: 0;
+    margin-top: 0px;
+    padding: 0;
+    font-weight: bold;
+    text-decoration: underline;
+  }
 }
 
 .one {

--- a/app/assets/stylesheets/pages/_concerts_index.scss
+++ b/app/assets/stylesheets/pages/_concerts_index.scss
@@ -67,6 +67,12 @@
   border-radius: 5px;
   position: relative;
   box-shadow: 0px 0px 30px rgb(15, 15, 15);
+  transition: all ease-in-out 0.2s;
+
+}
+.item:hover {
+  // box-shadow: 0px 0px 5px #1c979179;
+  transform: scale(1.02);
 
 }
 
@@ -123,16 +129,30 @@
   background: rgb(255,255,255);
   background: radial-gradient(circle, rgba(255,255,255,1) 0%, rgba(255,255,255,0) 70%);  height: fit-content;
 
+  a {
+    text-decoration: none;
+    color: #141414;
+  }
 
   span {
-    font-size: 22px;
+    font-size: 18px;
     font-family: $body-font;
     margin: 0;
     margin-top: 0px;
     padding: 0;
-    font-weight: bold;
+    font-weight:bold;
     text-decoration: underline;
+    color: #141414;
   }
+}
+.hover-disapear:hover {
+  a {
+    color: black;
+  }
+  span {
+    color: black;
+  }
+
 }
 
 .one {
@@ -143,21 +163,7 @@
 }
 
 
-.one:hover {
-  .hover-disapear {
-    opacity: 0;
 
-  }
-
-  .hover-appear {
-
-    opacity: 1;
-
-  }
-  img {
-    opacity: 0.5;
-  }
-}
 
 .concerts-layout {
   .btn-accent {

--- a/app/assets/stylesheets/pages/_concerts_index.scss
+++ b/app/assets/stylesheets/pages/_concerts_index.scss
@@ -1,0 +1,136 @@
+
+
+.concerts-layout {
+  padding: 50px;
+  background-color: rgb(20, 20, 20);
+}
+
+.masonry-grid {
+  margin-top: 70px;
+  margin-bottom: 100px;
+  width: 100%;
+  height: 100vh;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  grid-auto-rows: 200px;
+  grid-auto-flow: dense;
+  grid-gap: 20px;
+}
+
+.item:nth-child(1) {
+  background-color: #5ec4bfe0;
+  grid-column-end: span 2;
+  grid-row-end: span 1;
+}
+.item:nth-child(2) {
+  background-color: #5ec4bfe0;
+  grid-column-end: span 1;
+  grid-row-end: span 1;
+}
+.item:nth-child(3) {
+  background-color: #5ec4bfe0;
+  grid-column-end: span 1;
+  grid-row-end: span 2;
+}
+.item:nth-child(4) {
+  background-color: #5ec4bfe0;
+  grid-column-end: span 1;
+  grid-row-end: span 2;
+}
+.item:nth-child(5) {
+  background-color: #5ec4bfe0;
+  grid-column-end: span 3;
+  grid-row-end: span 1;
+}
+.item:nth-child(6) {
+  background-color: #5ec4bfe0;
+  grid-column-end: span 2;
+  grid-row-end: span 1;
+}
+.item:nth-child(7) {
+  background-color: #5ec4bfe0;
+  grid-column-end: span 1;
+  grid-row-end: span 1;
+}
+.item:nth-child(8) {
+  background-color: #5ec4bfe0;
+  grid-column-end: span 2;
+  grid-row-end: span 1;
+}
+
+
+
+
+
+
+.item {
+  background-color: #ccc;
+  border-radius: 5px;
+  position: relative;
+  box-shadow: 0px 0px 30px rgb(15, 15, 15);
+}
+
+
+
+.item-1-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 5px;
+  opacity: 0.8;
+}
+.masonry-date {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+
+}
+.hover-appear {
+  opacity: 0;
+  transition: opacity ease-in-out 0.3s;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  height: 100%;
+  font-size: 50px;
+  font-family: 'Bebas Neue', cursive;
+  a {
+    text-decoration: none;
+    color: black;
+    text-align: center;
+  }
+}
+
+.hover-disapear {
+  font-size: 50px;
+  font-family: 'Bebas Neue', cursive;
+  transition: opacity ease-in-out 0.3s;
+}
+
+.one {
+  img {
+    transition: opacity ease-in-out 0.2s;
+
+  }
+}
+
+
+.one:hover {
+  .hover-disapear {
+    opacity: 0;
+
+  }
+
+  .hover-appear {
+
+    opacity: 1;
+
+  }
+  img {
+    opacity: 0.5;
+  }
+}

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -4,3 +4,4 @@
 @import "saved_concerts";
 @import "artists_index";
 @import "profile";
+@import "concerts_index";

--- a/app/controllers/concerts_controller.rb
+++ b/app/controllers/concerts_controller.rb
@@ -8,6 +8,6 @@ class ConcertsController < ApplicationController
 
   def index
     @concerts = policy_scope(Concert)
-    @concerts = Concert.all
+    @concerts = Concert.all.first(8)
   end
 end

--- a/app/views/concerts/index.html.erb
+++ b/app/views/concerts/index.html.erb
@@ -22,13 +22,11 @@
     <% @concerts.each do |concert|   %>
     <div class="item one masonry-cell">
       <img class="item-1-img" src="https://media.istockphoto.com/id/1193274679/photo/excited-crowd-on-a-rock-concert.jpg?s=612x612&w=0&k=20&c=330XDxllhunHf5dt_IwMO2yxPBjXb5j_WMkf_0oWBmU=" alt="concert image">
-      <p class="masonry-date hover-disapear"><%= concert.artist.name%> <br><span> <%=concert.date.strftime("%B %d")%></span></p>
+      <p class="masonry-date hover-disapear"><%= link_to "#{concert.artist.name}", concert_path(concert), class: "" %> <br><span> <%=concert.date.strftime("%B %d")%></span></p>
 
 
 
-      <div class="hover-appear">
-        <p class="masonry-date ">    <%= link_to "#{concert.date.strftime("%B %d")}", concert_path(concert)%></p>
-      </div>
+
     </div>
     <% end %>
 

--- a/app/views/concerts/index.html.erb
+++ b/app/views/concerts/index.html.erb
@@ -1,5 +1,5 @@
 
-<div class="layout-container">
+<div class="concerts-layout">
 
   <div class="banner-one">
     <h1 class="text-center">Find your next concert!</h1>
@@ -14,28 +14,42 @@
   </div>
 
 
-  <div class="card-concert-container">
+
+  <div class="big-box">
+
+  <div class="masonry-grid">
+
     <% @concerts.each do |concert|   %>
+    <div class="item one masonry-cell">
+      <img class="item-1-img" src="https://media.istockphoto.com/id/1193274679/photo/excited-crowd-on-a-rock-concert.jpg?s=612x612&w=0&k=20&c=330XDxllhunHf5dt_IwMO2yxPBjXb5j_WMkf_0oWBmU=" alt="concert image">
+      <p class="masonry-date hover-disapear"><%= concert.artist.name %></p>
 
-      <div class="card-concert">
-        <div class="card-img">
-          <img src="https://media.istockphoto.com/id/1193274679/photo/excited-crowd-on-a-rock-concert.jpg?s=612x612&w=0&k=20&c=330XDxllhunHf5dt_IwMO2yxPBjXb5j_WMkf_0oWBmU=" alt="concert image">
-          <p class="img-date"><%= concert.date %></p>
-
-        </div>
-        <div class="card-body">
-          <div class="d-flex justify-content-between align-items-center">
-            <div><p class="card-header mb-2"><%= link_to concert.artist.name, artist_path(concert.artist) %></p></div>
-            <div><p><%= button_to "Save", {action: "create", :concert_id => concert.id, :controller => "saved_concerts", method: :post}, {class: "save"} %></p></div>
-          </div>
-          <p class="card-description"><strong></strong><%= concert.location %></p>
-          <div class="d-flex justify-content-center align-items-center">
-            <button class="btn-accent"><%= link_to "See more", concert_path(concert)%></button>
-          </div>
-        </div>
+      <div class="hover-appear">
+        <p class="masonry-date ">    <%= link_to "#{concert.date.strftime("%B %d")}", concert_path(concert)%></p>
       </div>
+    </div>
     <% end %>
+
+
+
+
+
+
+</div>
+
+
   </div>
+
+
+
+
+
+
+
+
+
+
+
 
   <div>
     <%= link_to "Go back", root_path, class: "btn btn-light my-5 rounded" %>

--- a/app/views/concerts/index.html.erb
+++ b/app/views/concerts/index.html.erb
@@ -43,15 +43,12 @@
 
 
 
-
-
-
-
-
-
-
-
-  <div>
+<div class="banner-one text-center">
     <%= link_to "Go back", root_path, class: "btn btn-light my-5 rounded" %>
+
   </div>
+
+
+
+
 </div>

--- a/app/views/concerts/index.html.erb
+++ b/app/views/concerts/index.html.erb
@@ -13,7 +13,11 @@
 
       <% @concerts.each do |concert|   %>
         <div class="item one masonry-cell">
-          <img class="item-1-img" src="https://media.istockphoto.com/id/1193274679/photo/excited-crowd-on-a-rock-concert.jpg?s=612x612&w=0&k=20&c=330XDxllhunHf5dt_IwMO2yxPBjXb5j_WMkf_0oWBmU=" alt="concert image">
+          <% if concert.artist.image_url %>
+            <img src="<%= concert.artist.image_url %>" alt="Concert image", class="item-1-img">
+          <% else %>
+            <img class="item-1-img" src="https://media.istockphoto.com/id/1193274679/photo/excited-crowd-on-a-rock-concert.jpg?s=612x612&w=0&k=20&c=330XDxllhunHf5dt_IwMO2yxPBjXb5j_WMkf_0oWBmU=" alt="concert image">
+          <% end %>
           <p class="masonry-date hover-disapear"><%= link_to "#{concert.artist.name}", concert_path(concert), class: "" %> <br><span> <%=concert.date.strftime("%B %d")%></span></p>
 
         </div>

--- a/app/views/concerts/index.html.erb
+++ b/app/views/concerts/index.html.erb
@@ -43,8 +43,8 @@
 
 
 
-<div class="banner-one text-center">
-    <%= link_to "Go back", root_path, class: "btn btn-light my-5 rounded" %>
+<div class="banner-one text-center back">
+    <%= link_to "Go back", root_path, class: "btn btn-accent" %>
 
   </div>
 

--- a/app/views/concerts/index.html.erb
+++ b/app/views/concerts/index.html.erb
@@ -22,7 +22,9 @@
     <% @concerts.each do |concert|   %>
     <div class="item one masonry-cell">
       <img class="item-1-img" src="https://media.istockphoto.com/id/1193274679/photo/excited-crowd-on-a-rock-concert.jpg?s=612x612&w=0&k=20&c=330XDxllhunHf5dt_IwMO2yxPBjXb5j_WMkf_0oWBmU=" alt="concert image">
-      <p class="masonry-date hover-disapear"><%= concert.artist.name %></p>
+      <p class="masonry-date hover-disapear"><%= concert.artist.name%> <br><span> <%=concert.date.strftime("%B %d")%></span></p>
+
+
 
       <div class="hover-appear">
         <p class="masonry-date ">    <%= link_to "#{concert.date.strftime("%B %d")}", concert_path(concert)%></p>

--- a/app/views/concerts/index.html.erb
+++ b/app/views/concerts/index.html.erb
@@ -2,40 +2,23 @@
 <div class="concerts-layout">
 
   <div class="banner-one">
-    <h1 class="text-center">Find your next concert!</h1>
-    <%= form_with url: artists_path, method: :get, class: "d-flex search-form-border" do %>
-      <%= text_field_tag :query,
-        params[:query],
-        class: "form-control search-input-dark",
-        placeholder: "Find an artist"
-      %>
-      <%= submit_tag "Search", class: "search-btn" %>
-    <% end %>
+    <h1 class="text-center">Concerts from your favourite artists!    <i class="fa-solid fa-heart pink"></i> </h1>
   </div>
 
 
 
   <div class="big-box">
 
-  <div class="masonry-grid">
+    <div class="masonry-grid">
 
-    <% @concerts.each do |concert|   %>
-    <div class="item one masonry-cell">
-      <img class="item-1-img" src="https://media.istockphoto.com/id/1193274679/photo/excited-crowd-on-a-rock-concert.jpg?s=612x612&w=0&k=20&c=330XDxllhunHf5dt_IwMO2yxPBjXb5j_WMkf_0oWBmU=" alt="concert image">
-      <p class="masonry-date hover-disapear"><%= link_to "#{concert.artist.name}", concert_path(concert), class: "" %> <br><span> <%=concert.date.strftime("%B %d")%></span></p>
+      <% @concerts.each do |concert|   %>
+        <div class="item one masonry-cell">
+          <img class="item-1-img" src="https://media.istockphoto.com/id/1193274679/photo/excited-crowd-on-a-rock-concert.jpg?s=612x612&w=0&k=20&c=330XDxllhunHf5dt_IwMO2yxPBjXb5j_WMkf_0oWBmU=" alt="concert image">
+          <p class="masonry-date hover-disapear"><%= link_to "#{concert.artist.name}", concert_path(concert), class: "" %> <br><span> <%=concert.date.strftime("%B %d")%></span></p>
 
-
-
-
+        </div>
+      <% end %>
     </div>
-    <% end %>
-
-
-
-
-
-
-</div>
 
 
   </div>


### PR DESCRIPTION
I had an idea for a different version of concerts index page:
- Where we could use the image of the concert for the background of the cards
- On hover: it will show up the date, and if we click on it, it will redirect to the concert page

Its just on option, if you guys like it...



![Screenshot 2023-03-23 at 19-38-40 Concertify](https://user-images.githubusercontent.com/115821034/227333340-e7a0591e-b685-4679-9cd0-d38ff831d854.png)
